### PR TITLE
[airmap] Go 1.12 fixes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -17,7 +17,7 @@ A simple program to create a georeferenced blank 256x256 GeoTIFF:
 	import (
 		"fmt"
 		"flag"
-		gdal "github.com/lukeroth/gdal_go"
+		gdal "github.com/airmap/gdal"
 	)
 
 	func main() {

--- a/examples/test_tiff/test_tiff.go
+++ b/examples/test_tiff/test_tiff.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"flag"
-	"github.com/lukeroth/gdal"
+	"fmt"
+
+	"github.com/airmap/gdal"
 )
 
 func main() {

--- a/examples/test_tiff/test_tiff.go
+++ b/examples/test_tiff/test_tiff.go
@@ -15,15 +15,15 @@ func main() {
 		return
 	}
 	fmt.Printf("Filename: %s\n", filename)
-	
+
 	fmt.Printf("Allocating buffer\n")
 	var buffer [256 * 256]uint8
 	//	buffer := make([]uint8, 256 * 256)
-	
+
 	fmt.Printf("Computing values\n")
 	for x := 0; x < 256; x++ {
 		for y := 0; y < 256; y++ {
-			loc := x + y * 256
+			loc := x + y*256
 			val := x + y
 			if val >= 256 {
 				val -= 256
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	fmt.Printf("%d drivers available\n", gdal.GetDriverCount())
-	for x:= 0; x < gdal.GetDriverCount(); x++ {
+	for x := 0; x < gdal.GetDriverCount(); x++ {
 		driver := gdal.GetDriver(x)
 		fmt.Printf("%s: %s\n", driver.ShortName(), driver.LongName())
 	}
@@ -47,7 +47,7 @@ func main() {
 	fmt.Printf("Creating dataset\n")
 	dataset := driver.Create(filename, 256, 256, 1, gdal.Byte, nil)
 	defer dataset.Close()
-	
+
 	fmt.Printf("Creating projection\n")
 	spatialRef := gdal.CreateSpatialReference("")
 
@@ -71,12 +71,12 @@ func main() {
 
 	fmt.Printf("Reading geotransform:")
 	geoTransform := dataset.GeoTransform()
-	fmt.Printf("%v, %v, %v, %v, %v, %v\n", 
+	fmt.Printf("%v, %v, %v, %v, %v, %v\n",
 		geoTransform[0], geoTransform[1], geoTransform[2], geoTransform[3], geoTransform[4], geoTransform[5])
 
 	fmt.Printf("Reading projection:")
 	wkt := dataset.Projection()
 	fmt.Printf("%s\n", wkt)
-		
-	fmt.Printf("End program\n")	
+
+	fmt.Printf("End program\n")
 }

--- a/gdal.go
+++ b/gdal.go
@@ -46,7 +46,7 @@ var (
 )
 
 // Error handling.  The following is bare-bones, and needs to be replaced with something more useful.
-func (err _Ctype_CPLErr) Err() error {
+func (err C.CPLErr) Err() error {
 	switch err {
 	case 0:
 		return nil
@@ -62,7 +62,7 @@ func (err _Ctype_CPLErr) Err() error {
 	return ErrIllegal
 }
 
-func (err _Ctype_OGRErr) Err() error {
+func (err C.OGRErr) Err() error {
 	switch err {
 	case 0:
 		return nil


### PR DESCRIPTION
Before this change, `gdal` will not compile with Go 1.12:

```sh
$ go build github.com/airmap/gdal
# github.com/airmap/gdal
./gdal.go:49:11: identifier "_Ctype_CPLErr" may conflict with identifiers generated by cgo
./gdal.go:65:11: identifier "_Ctype_OGRErr" may conflict with identifiers generated by cgo
```

This PR fixes this.

There are also some lingering references to `github.com/lukeroth/gdal` which result in it being included as a dependency in `go.mod`. This PR removes those so `go.mod` is clean.

Finally, there are some minor Go formatting fixes.