### PR TITLE
Update tiff example

### DIFF
--- a/examples/tiff/go.mod
+++ b/examples/tiff/go.mod
@@ -1,7 +1,5 @@
-module github.com/lukeroth/gdal/examples/tiff
+module github.com/airmap/gdal/examples/tiff
 
 go 1.13
 
-replace github.com/lukeroth/gdal => ../..
-
-require github.com/lukeroth/gdal v0.0.0-00010101000000-000000000000
+require github.com/airmap/gdal v0.0.5

--- a/examples/tiff/tiff.go
+++ b/examples/tiff/tiff.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
-
 	"github.com/airmap/gdal"
+	"github.com/airmap/gdal/ogr"
 )
 
 func main() {
@@ -17,8 +17,7 @@ func main() {
 	fmt.Printf("Filename: %s\n", filename)
 
 	fmt.Printf("Allocating buffer\n")
-	var buffer [256 * 256]uint8
-	//	buffer := make([]uint8, 256 * 256)
+	buffer := make([]uint8, 256*256)
 
 	fmt.Printf("Computing values\n")
 	for x := 0; x < 256; x++ {
@@ -49,7 +48,7 @@ func main() {
 	defer dataset.Close()
 
 	fmt.Printf("Creating projection\n")
-	spatialRef := gdal.CreateSpatialReference("")
+	spatialRef := ogr.CreateSpatialReference("")
 
 	fmt.Printf("Setting EPSG code\n")
 	spatialRef.FromEPSG(3857)


### PR DESCRIPTION
This PR fixes two issues:

1. The CreateSpatialReference function moved to package ogr, which broke the build.
2. The IO function expects a slice, not an array, which prevented writing the data to the tiff file.

While fixing these two issues I updated the go.mod file.
